### PR TITLE
Fix path issue when running as .jar

### DIFF
--- a/msal-client-credential-certificate/pom.xml
+++ b/msal-client-credential-certificate/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.1</version>
         </dependency>
     </dependencies>
 

--- a/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
@@ -9,7 +9,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
@@ -113,7 +113,7 @@ class ClientCredentialGrant {
     private static void setUpSampleData() throws IOException {
         // Load properties file and set properties used throughout the sample
         Properties properties = new Properties();
-        properties.load(new FileInputStream(Thread.currentThread().getContextClassLoader().getResource("").getPath() + "application.properties"));
+        properties.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("application.properties"));
         authority = properties.getProperty("AUTHORITY");
         clientId = properties.getProperty("CLIENT_ID");
         keyPath = properties.getProperty("KEY_PATH");

--- a/msal-client-credential-secret/pom.xml
+++ b/msal-client-credential-secret/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.1</version>
         </dependency>
     </dependencies>
 

--- a/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
@@ -96,7 +96,7 @@ class ClientCredentialGrant {
     private static void setUpSampleData() throws IOException {
         // Load properties file and set properties used throughout the sample
         Properties properties = new Properties();
-        properties.load(new FileInputStream(Thread.currentThread().getContextClassLoader().getResource("").getPath() + "application.properties"));
+        properties.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("application.properties"));
         authority = properties.getProperty("AUTHORITY");
         clientId = properties.getProperty("CLIENT_ID");
         secret = properties.getProperty("SECRET");

--- a/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
@@ -8,7 +8,6 @@ import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;


### PR DESCRIPTION
Fixes an issue found in https://github.com/Azure-Samples/ms-identity-java-daemon/issues/8, related to reading data from the configuration file

After changes made in https://github.com/Azure-Samples/ms-identity-java-daemon/pull/7 moved configuration to a separate file, the method to read that file was only tested directly in IntelliJ, and not after packaging the sample as a .jar as described in the README. As shown in https://github.com/Azure-Samples/ms-identity-java-daemon/issues/8, the original method to read the config file causes a null pointer exception