### PR TITLE
Replace deprecated URL constructor

### DIFF
--- a/msal-client-credential-certificate/README.md
+++ b/msal-client-credential-certificate/README.md
@@ -184,7 +184,7 @@ The relevant code for this sample is in the `ClientCredentialGrant.java` file.
     In this case calling "https://graph.microsoft.com/v1.0/users" with the access token as a bearer token.
 
     ```Java
-       URL url = new URL("https://graph.microsoft.com/v1.0/users");
+       URL url = new URI("https://graph.microsoft.com/v1.0/users").toURL();
        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
        //...

--- a/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-certificate/src/main/java/ClientCredentialGrant.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -82,8 +84,8 @@ class ClientCredentialGrant {
         return future.get();
     }
 
-    private static String getUsersListFromGraph(String accessToken) throws IOException {
-        URL url = new URL("https://graph.microsoft.com/v1.0/users");
+    private static String getUsersListFromGraph(String accessToken) throws IOException, URISyntaxException {
+        URL url = new URI("https://graph.microsoft.com/v1.0/users").toURL();
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
         conn.setRequestMethod("GET");

--- a/msal-client-credential-secret/README.md
+++ b/msal-client-credential-secret/README.md
@@ -171,7 +171,7 @@ The relevant code for this sample is in the `ClientCredentialGrant.java` file.
     In this case calling "https://graph.microsoft.com/v1.0/users" with the access token as a bearer token.
 
     ```Java
-       URL url = new URL("https://graph.microsoft.com/v1.0/users");
+       URL url = new URI("https://graph.microsoft.com/v1.0/users").toURL();
        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
        //...

--- a/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
+++ b/msal-client-credential-secret/src/main/java/ClientCredentialGrant.java
@@ -11,6 +11,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Properties;
@@ -65,8 +67,8 @@ class ClientCredentialGrant {
         return future.get();
     }
 
-    private static String getUsersListFromGraph(String accessToken) throws IOException {
-        URL url = new URL("https://graph.microsoft.com/v1.0/users");
+    private static String getUsersListFromGraph(String accessToken) throws IOException, URISyntaxException {
+        URL url = new URI("https://graph.microsoft.com/v1.0/users").toURL();
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
         conn.setRequestMethod("GET");


### PR DESCRIPTION
new URL(String) is deprecated from Java 20 on.